### PR TITLE
Tweak several default settings for convenience

### DIFF
--- a/data/defaults.cfg
+++ b/data/defaults.cfg
@@ -5,14 +5,14 @@ name "unnamed"
 
 invmouse 0         // 1 for flightsim mode
 sensitivity 3      // similar number to quake
-fov 100            // 90 is default in other games
+fov 107            // 90 is default in other games
 
 musicvol 30       // set higher if you want (max 255)
-soundvol 255      // sounds average volume is actually set per sound, average 100
+soundvol 120      // sounds average volume is actually set per sound, average 100
 
 gamma 100          // set to your liking, 100 = default
 
-fullbrightmodels 60 // make player models a bit easier to see
+fullbrightmodels 75 // make player models a bit easier to see
 
 shadowmapsize 11	// adds more pixels to the models' shadow
 blurshadowmap 0		// removes shadow blur effect by default
@@ -25,10 +25,10 @@ outlinemeters 1 // 1 shows base outline
 
 // console
 
-consize 4            // console is 4 lines
+consize 5            // console is 4 lines
 miniconsize 5        // mini-console is 5 lines
 miniconwidth 40      // mini-console is 40% of screen width
-fullconsize 75       // full console is 75% of screen height
+fullconsize 85       // full console is 85% of screen height
 miniconfilter 0x300  // display chat and team chat in mini-console
 confilter (&~ 0x2FFF $miniconfilter) // don't display other player frags or mini-console stuff in console
 fullconfilter 0xFFFF // display all messages in full console
@@ -39,6 +39,11 @@ bind W forward
 bind A left
 bind S backward
 bind D right
+
+// support AZERTY keyboards out of the box on Linux
+// this won't work in edit mode, but it's better than nothing
+bind Z forward
+bind Q left
 
 bind UP [ if (= $thirdperson 2) [thirdpersonup (+ $thirdpersonup 1)] [forward] ]
 bind DOWN [ if (= $thirdperson 2) [thirdpersonup (- $thirdpersonup 1)] [backward] ]
@@ -67,7 +72,7 @@ bind 7 "setweapon FI"
 bind SPACE "jump"
 bind MOUSE2 [fastsaw]
 bind MOUSE1 "attack"
-bind MOUSE3 "weapon"
+bind MOUSE3 [zoom 1; onrelease [zoom -1]]
 specbind MOUSE1 "nextfollow"
 specbind MOUSE2 "nextfollow -1"
 specbind MOUSE3 "follow"
@@ -107,7 +112,7 @@ bind E edittoggle
 
 bind F7 [if (! $cleargui)[if (|| (= $editing 1) (= (m_edit (getmode)) 1))[showgui "editing"]]]
 
-bind U "suicide"
+bind K "suicide"
 
 bind LCTRL "allowspedit"
 bind RCTRL "allowspedit"
@@ -130,7 +135,6 @@ bind MOUSE4 [ universaldelta 1 ]	// also used for editing, see below
 bind MOUSE5 [ universaldelta -1 ]
 
 bind G [ togglezoom ]
-bind Z [ togglezoom ]
 
 //////////////////////////////////
 // Tomatenquark Editing related bindings
@@ -221,4 +225,3 @@ editbind KP5 [setblendpaintmode 5]
 
 editbind KP8 [scrollblendbrush -1]
 editbind KP9 [scrollblendbrush 1]
-

--- a/data/menus.cfg
+++ b/data/menus.cfg
@@ -129,10 +129,10 @@ newgui playermodel [
             guicheckbox "always use team skins" teamskins
         ]
         guilist [
-            guicheckbox "fullbright" fullbrightmodels 60 0
+            guicheckbox "fullbright" fullbrightmodels 75 0
             if $fullbrightmodels [
                 guibar
-                guiradio "subtle" fullbrightmodels 60
+                guiradio "subtle" fullbrightmodels 75
                 guiradio "bright" fullbrightmodels 100
                 guiradio "overbright" fullbrightmodels 150
                 guiradio "max" fullbrightmodels 200
@@ -1059,7 +1059,7 @@ newgui options [
 	]
 
     guitab   "^f8resolution"
-    guitext "field of view (default: 100)"
+    guitext "horizontal field of view (default: 107)"
     guislider fov
     guistayopen [
       guilist [


### PR DESCRIPTION
- Use a FOV that works well with 16:9 displays by default.
- Clarify in the menus that the FOV setting is horizontal, not vertical.
  - In the long run, we should make the FOV setting vertical so it's independent of the aspect ratio. That's for another PR :slightly_smiling_face: 
- Bind movement keys for AZERTY keyboards as well. This improves the out-of-the-box experience for Linux users.
- Bind the middle mouse button to a "hold" zoom action. G is still available for toggle-zooming.
- Make players slightly brighter by default so they can't hide in dark corners so much.
- Decrease the default sound volume to be closer to the music volume.
- Bind K to suicide instead of U as it's more common.
- Make the console display 5 lines to have a bit more context without having to reach for the full console.
  - Make the full console cover 85% of the screen so it leaves just the chat line and HUD uncovered.